### PR TITLE
Update opts in pair.ts

### DIFF
--- a/cmd/pair.ts
+++ b/cmd/pair.ts
@@ -8,6 +8,7 @@ const opts = {
   debug: true,
   ansi: true,
   discovery_ip: "192.168.1.255",
+  attempt_to_fix_packet_loss: false,
 };
 
 let sessions: Record<string, Session> = {};


### PR DESCRIPTION
Update opts in pair.ts to include attempt_to_fix_packet_loss.

Otherwise it will fail with:

```
cmd/pair.ts:16:29 - error TS2345: Argument of type '{ debug: boolean; ansi: boolean; discovery_ip: string; }' is not assignable to parameter of type 'opt'.
  Property 'attempt_to_fix_packet_loss' is missing in type '{ debug: boolean; ansi: boolean; discovery_ip: string; }' but required in type 'opt'.
```