### PR TITLE
Set discovery_ip in http_server.ts back to 192.168.1.255

### DIFF
--- a/http_server.ts
+++ b/http_server.ts
@@ -11,7 +11,8 @@ const opts = {
   debug: false,
   ansi: false,
   // discovery_ip: "192.168.40.255", //, "192.168.1.255"
-  discovery_ip: "192.168.40.104",
+  // discovery_ip: "192.168.40.104",
+  discovery_ip: "192.168.1.255",
   attempt_to_fix_packet_loss: false,
   //attempt_to_fix_packet_loss: true,
 };


### PR DESCRIPTION
The previous value (192.168.40.104) seems to be leftover debugging, as it's not a broadcast address and thus causes the server not to find any cameras.