### PR TITLE
Drop newline in the activity indicator

### DIFF
--- a/discovery.ts
+++ b/discovery.ts
@@ -34,7 +34,7 @@ export const discoverDevices = (debug: boolean, discovery_ip: string): EventEmit
 
     let buf = create_LanSearch();
     setInterval(() => {
-      console.log(".");
+      process.stdout.write(".");
       sock.send(new Uint8Array(buf.buffer), SEND_PORT, discovery_ip);
     }, 2000);
     sock.send(new Uint8Array(buf.buffer), SEND_PORT, discovery_ip);


### PR DESCRIPTION
The "." character is printed on a new line every 2s to indicate that the discovery process is running. However, using a new line unnecessary floods the output log; switch to printing "." without a newline, keeping the activity indicator while also drastically reducing the number of lines in the output log.