### PR TITLE
implement rotation via injecting exif headers

### DIFF
--- a/asd.html
+++ b/asd.html
@@ -3,8 +3,10 @@
 	<link rel="shortcut icon" href="/favicon.ico">
 	<title>${name}</title>
 	</head><body>
-	<h2>${name}</h2><a href="/camera/${id}"><img src="/camera/${id}"/></a><hr/>
+	<h2>${name}</h2><a href="/camera/${id}"><img style="height: 640px" src="/camera/${id}"/></a><hr/>
 	<button onclick="toggle_audio()" id=audio disabled=true>Audio: disabled</button>
+	<button onclick="fetch('/rotate/${id}')">Rotate</button>
+	<button onclick="fetch('/mirror/${id}')">Mirror</button>
 	<script>
 	const alaw_to_s16_table = [
 	  -5504, -5248, -6016, -5760, -4480, -4224, -4992, -4736, -7552, -7296, -8064, -7808, -6528, -6272, -7040, -6784, -2752,
@@ -49,13 +51,11 @@
 		audio_context.resume();
 
 		const evtSource = new EventSource("/audio/${id}");
-		if (${debug}) {
-			evtSource.onopen = (e) => {
-				console.log("evtsource open");
-			}
-			evtSource.onerror = (e) => {
-				console.log("evtsource error", e);
-			}
+		evtSource.onopen = (e) => {
+			console.log("evtsource open");
+		}
+		evtSource.onerror = (e) => {
+			console.log("evtsource error", e);
 		}
 		let endsAt = 0;
 		let startAt = 0;

--- a/exif.ts
+++ b/exif.ts
@@ -1,0 +1,28 @@
+// Create a minimal EXIF segment with orientation
+export const createExifOrientation = (orientation: number) => {
+  const tiffHeader = Buffer.from("49492A0008000000", "hex");
+  const ifdEntry = Buffer.concat([
+    Buffer.from("0100", "hex"), // Number of IFD entries
+    Buffer.from("1201030001000000", "hex"), // Tag, Type, Count
+    Buffer.from(orientation.toString(16).padStart(2, "0"), "hex"), // Orientation value
+    Buffer.from("0000", "hex"), // No more IFDs
+    Buffer.from("0000000000", "hex"), // padding??
+  ]);
+
+  const exifData = Buffer.concat([Buffer.from("457869660000", "hex"), tiffHeader, ifdEntry]);
+  const segmentLength = Buffer.from([(exifData.length + 2) >> 8, (exifData.length + 2) & 0xff]);
+  const exifHeader = Buffer.concat([Buffer.from("FFE1", "hex"), segmentLength]);
+
+  return Buffer.concat([exifHeader, exifData]);
+};
+
+export const addExifToJpeg = (jpegData: Buffer, exifSegment: Buffer) => {
+  // Check for existing EXIF (simplified check)
+  if (jpegData.includes(Buffer.from("FFE1", "hex"))) {
+    throw new Error("JPEG already contains EXIF segment");
+  }
+
+  const soiEnd = 2; // After FFD8
+  const modifiedJpeg = Buffer.concat([jpegData.subarray(0, soiEnd), exifSegment, jpegData.subarray(soiEnd)]);
+  return modifiedJpeg;
+};


### PR DESCRIPTION
This PR adds support for rotating/mirroring cameras individually.
The rotation/mirroring state is only kept in memory; restarting the server will lose these values.
The overhead is minimal, the EXIF header is 36 bytes per frame (~10KiB)

https://github.com/DavidVentura/cam-reverse/assets/3650670/a033b5e9-1226-43ab-941c-34e8e97cc13b

