### PR TITLE
Fix sending favicon in http_server

### DIFF
--- a/http_server.ts
+++ b/http_server.ts
@@ -86,7 +86,7 @@ export const serveHttp = (opts: opt, port: number, with_audio: boolean) => {
     if (req.url.startsWith("/favicon.ico")) {
       res.setHeader("Content-Type", "image/x-icon");
       res.setHeader("Content-Encoding", "gzip");
-      res.end(favicon);
+      res.end(Buffer.from(favicon));
       return;
     }
 


### PR DESCRIPTION
`favicon` is now an array, and `end()` expects a Buffer or String.

Fixes #20.