### PR TITLE
Fix crashes when pkt_id 1 is dropped

### DIFF
--- a/handlers.ts
+++ b/handlers.ts
@@ -269,7 +269,7 @@ const deal_with_data = (session: Session, dv: DataView) => {
           return;
         }
 
-        if (session.curImage.length == 1) return; // header does not have markers
+        if (session.curImage.length <= 1) return; // header does not have markers
 
         let lastFrameSlice = session.curImage[session.curImage.length - 1];
         const lastResetMarker = findAllResetMarkers(lastFrameSlice).pop();


### PR DESCRIPTION
This fixes a rare crash when packet seq 1 was dropped.
```sh
2024-07-04T04:51:44.884Z [debug] Removing 1 from pending
2024-07-04T04:51:44.884Z [debug] Removing 2 from pending
2024-07-04T04:51:44.925Z [debug] Video param set ack
2024-07-04T04:51:44.987Z [debug] Start video ack
2024-07-04T04:51:45.230Z [debug] Dropping corrupt frame 2, expected 1
[...]/cam-reverse/dist/bin.cjs:24963
  for (let i = 0; i < b.length - 1; i++) {
                        ^

TypeError: Cannot read properties of undefined (reading 'length')
    at findAllResetMarkers ([...]/cam-reverse/dist/bin.cjs:24963:25)
    at deal_with_data ([...]/cam-reverse/dist/bin.cjs:24941:33)
    at Object.handle_Drw [as Drw] ([...]/cam-reverse/dist/bin.cjs:25004:5)
    at handleIncoming ([...]/cam-reverse/dist/bin.cjs:25026:16)
    at Socket.<anonymous> ([...]/cam-reverse/dist/bin.cjs:25039:38)
    at Socket.emit (node:events:520:28)
    at UDP.onMessage [as onmessage] (node:dgram:944:8)

```

The crash can be reproduced by deliberately dropping packet seq 1:

```diff
diff --git a/handlers.ts b/handlers.ts
index 9874e86..2082dca 100644
--- a/handlers.ts
+++ b/handlers.ts
@@ -205,6 +205,9 @@ const deal_with_data = (session: Session, dv: DataView) => {
   const STREAM_TYPE_AUDIO = 0x06;
   const STREAM_TYPE_JPEG = 0x03;
 
+  if (pkt_id == 1)
+    return;
+
   const startNewFrame = (buf: ArrayBuffer) => {
     if (session.curImage.length > 0 && !session.frame_is_bad) {
       session.eventEmitter.emit("frame");
```

The above will creates the scenario where `session.curImage` is an empty array